### PR TITLE
Removed unnecessary `title` variable

### DIFF
--- a/lib/myApp.dart
+++ b/lib/myApp.dart
@@ -12,7 +12,7 @@ class MyApp extends StatelessWidget {
       theme: new ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: new MyHomePage(title: "Home Page"),
+      home: new MyHomePage(),
       routes: <String, WidgetBuilder> {
         "login" : (BuildContext context) => new LoginPage(),
       }
@@ -21,8 +21,7 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key key, this.title}) : super(key: key);
-  final String title;
+  MyHomePage({Key key}) : super(key: key);
 
   @override
   _MyHomePageState createState() => new _MyHomePageState();


### PR DESCRIPTION
The alternative is to change the scaffold to use `widget.title` instead of the static "Home Page"